### PR TITLE
Disable hooks if instrumentation is detected

### DIFF
--- a/src/de/robv/android/xposed/XposedBridge.java
+++ b/src/de/robv/android/xposed/XposedBridge.java
@@ -33,6 +33,7 @@ import java.util.TreeSet;
 import android.app.ActivityThread;
 import android.app.AndroidAppHelper;
 import android.app.LoadedApk;
+import android.content.ComponentName;
 import android.content.pm.ApplicationInfo;
 import android.content.res.CompatibilityInfo;
 import android.content.res.Configuration;
@@ -57,6 +58,7 @@ public final class XposedBridge {
 	private static PrintWriter logWriter = null;
 	// log for initialization of a few mods is about 500 bytes, so 2*20 kB (2*~350 lines) should be enough
 	private static final int MAX_LOGFILE_SIZE = 20*1024; 
+	private static boolean disableHooks;
 	
 	private static final Object[] EMPTY_ARRAY = new Object[0];
 	public static final ClassLoader BOOTCLASSLOADER = ClassLoader.getSystemClassLoader();
@@ -124,6 +126,12 @@ public final class XposedBridge {
 		findAndHookMethod(ActivityThread.class, "handleBindApplication", "android.app.ActivityThread.AppBindData", new XC_MethodHook() {
 			protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
 				ActivityThread activityThread = (ActivityThread) param.thisObject;
+				ComponentName instrumentationName = (ComponentName) getObjectField(param.args[0], "instrumentationName");
+				if (instrumentationName != null) {
+					XposedBridge.log("Instrumentation detected, disabling framework for this process");
+					XposedBridge.disableHooks = true;
+					return;
+				}
 				ApplicationInfo appInfo = (ApplicationInfo) getObjectField(param.args[0], "appInfo");
 				CompatibilityInfo compatInfo = (CompatibilityInfo) getObjectField(param.args[0], "compatInfo");
 				if (appInfo.sourceDir == null)
@@ -148,6 +156,9 @@ public final class XposedBridge {
 		findAndHookMethod("com.android.server.ServerThread", null, "run", new XC_MethodHook() {
 			@Override
 			protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+				if (XposedBridge.disableHooks) {
+					return;
+				}
 				loadedPackagesInProcess.add("android");
 				
 				LoadPackageParam lpparam = new LoadPackageParam(loadedPackageCallbacks);
@@ -164,6 +175,9 @@ public final class XposedBridge {
 		hookAllConstructors(LoadedApk.class, new XC_MethodHook() {
 			@Override
 			protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+				if (XposedBridge.disableHooks) {
+					return;
+				}
 				LoadedApk loadedApk = (LoadedApk) param.thisObject;
 
 				String packageName = loadedApk.getPackageName();
@@ -188,6 +202,9 @@ public final class XposedBridge {
 				ApplicationInfo.class, new XC_MethodHook() {
 			@Override
 			protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+				if (XposedBridge.disableHooks) {
+					return;
+				}
 				ApplicationInfo app = (ApplicationInfo) param.args[0];
 				XResources.setPackageNameForResDir(app.packageName,
 					app.uid == Process.myUid() ? app.sourceDir : app.publicSourceDir);
@@ -522,6 +539,9 @@ public final class XposedBridge {
 	 */
 	private static XC_MethodHook callbackGetTopLevelResources = new XC_MethodHook(XCallback.PRIORITY_HIGHEST - 10) {
 		protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+			if (XposedBridge.disableHooks) {
+				return;
+			}
 			XResources newRes = null;
 			final Object result = param.getResult();
 			if (result instanceof XResources) {


### PR DESCRIPTION
Detect instrumentation at application binding.
New static flag in XposedBridge which acts as a "kill switch" for
user installed mods - that flag is enabled when instrumentation is
detected. My understanding is that once the initial hook (the one detecting instrumentation) is fired, the VM was already forked so altering a static variable doesn't affect other past or future processes.

If you are instrumentating an application, you're likely to already have the source code, hence won't be needing to alter the behavior using Xposed.
Also, current Xposed implementation doesn't handle the way instrumentation loads classes from another classloader.

http://forum.xda-developers.com/showpost.php?p=41688269&postcount=1517
