### PR TITLE
Add tag to log method

### DIFF
--- a/src/de/robv/android/xposed/XposedBridge.java
+++ b/src/de/robv/android/xposed/XposedBridge.java
@@ -475,6 +475,15 @@ public final class XposedBridge {
 	}
 	
 	/**
+	 * Writes a message to BASE_DIR/log/debug.log (needs to have chmod 777)
+	 * @param tag Used to identify the source of a log message.
+	 * @param text log message
+	 */
+	public synchronized static void log(String tag, String text) {
+		log(tag + ": " + text);
+	}
+
+	/**
 	 * Log the stack trace
 	 * @param t The Throwable object for the stacktrace
 	 * @see XposedBridge#log(String)

--- a/src/de/robv/android/xposed/XposedBridge.java
+++ b/src/de/robv/android/xposed/XposedBridge.java
@@ -495,6 +495,20 @@ public final class XposedBridge {
 			logWriter.flush();
 		}
 	}
+	
+	/**
+	 * Log the stack trace
+	 * @param tag Used to identify the source of a log message.
+	 * @param t The Throwable object for the stacktrace
+	 * @see XposedBridge#log(String)
+	 */
+	public synchronized static void log(String tag, Throwable t) {
+		Log.i("Xposed", tag + ": " + Log.getStackTraceString(t));
+		if (logWriter != null) {
+			t.printStackTrace(logWriter);
+			logWriter.flush();
+		}
+	}
 
 	/**
 	 * Hook any method with the specified callback


### PR DESCRIPTION
The tag would help identify which module is logging to Xposed's logs, right now the module itself needs to do this, or else it's all a big mess.

Ideally, the old log method should be deprecated and eventually removed.
