### PR TITLE
log -> logError

### DIFF
--- a/src/de/robv/android/xposed/XposedBridge.java
+++ b/src/de/robv/android/xposed/XposedBridge.java
@@ -469,12 +469,12 @@ public final class XposedBridge {
 	 * <p>DON'T FLOOD THE LOG!!! This is only meant for error logging.
 	 * If you want to write information/debug messages, use logcat.
 	 *
-	 * @param text The log message.
+	 * @param error The log message.
 	 */
-	public synchronized static void log(String text) {
-		Log.i("Xposed", text);
+	public synchronized static void logError(String error) {
+		Log.i("Xposed", error);
 		if (logWriter != null) {
-			logWriter.println(text);
+			logWriter.println(error);
 			logWriter.flush();
 		}
 	}


### PR DESCRIPTION
Since some developers use this as "logcat" (such modules flood xposed log), we should rename this API to point for what it is.
