### PR TITLE
Fix linting error

### DIFF
--- a/hiddenapistubs/src/main/java/android/content/res/CompatibilityInfo.java
+++ b/hiddenapistubs/src/main/java/android/content/res/CompatibilityInfo.java
@@ -13,4 +13,6 @@ public class CompatibilityInfo implements Parcelable {
 	public void writeToParcel(Parcel dest, int flags) {
 		throw new UnsupportedOperationException("STUB");
 	}
+
+	public static final Parcelable.Creator<CompatibilityInfo> CREATOR = null;
 }


### PR DESCRIPTION
`Parcelable` implementations must define a CREATOR or lint complains and aborts the build of the `hiddenapistubs` project.
