### PR TITLE
Skip Xposed API classes check if needed

### DIFF
--- a/app/src/main/java/de/robv/android/xposed/XposedInit.java
+++ b/app/src/main/java/de/robv/android/xposed/XposedInit.java
@@ -389,7 +389,9 @@ import static de.robv.android.xposed.XposedHelpers.setStaticObjectField;
 			return;
 		}
 
-		if (dexFile.loadClass(XposedBridge.class.getName(), topClassLoader) != null) {
+		boolean ignoreModuleXposedClassesError = SELinuxHelper.getAppDataFileService().checkFileExists(BASE_DIR + "conf/ignore_module_xposed_classes_error");
+
+		if (!ignoreModuleXposedClassesError && dexFile.loadClass(XposedBridge.class.getName(), topClassLoader) != null) {
 			Log.e(TAG, "  Cannot load module:");
 			Log.e(TAG, "  The Xposed API classes are compiled into the module's APK.");
 			Log.e(TAG, "  This may cause strange issues and must be fixed by the module developer.");


### PR DESCRIPTION
There are still many modules, which are wrongly compiled, but still can work just fine on LP, MM or later. Many of them are as is, without chance to be updated for Android Studio, Grandle and new Xposed API.

This patch allows us to add option to Xposed Installer's Settings to enable running of modules, which are outdated and Xposed classes are compiled into module's APK.
