### PR TITLE
Added missing parameter to Javadoc of findAndHookMethod()

### DIFF
--- a/app/src/main/java/de/robv/android/xposed/XposedHelpers.java
+++ b/app/src/main/java/de/robv/android/xposed/XposedHelpers.java
@@ -228,7 +228,7 @@ public final class XposedHelpers {
 	 * }
 	 *
 	 * // ... you can use this call:
-	 * findAndHookMethod("com.example.SomeClass", lpparam.classLoader, String.class, int.class, "com.example.MyClass", new XC_MethodHook() {
+	 * findAndHookMethod("com.example.SomeClass", lpparam.classLoader, "doSomething", String.class, int.class, "com.example.MyClass", new XC_MethodHook() {
 	 *   &#64;Override
 	 *   protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
 	 *     String oldText = (String) param.args[0];


### PR DESCRIPTION
It looks like the Javadoc was missing the methodName parameter in the example given.