### PR TITLE
Try other filenames if apk can't be found

### DIFF
--- a/app/src/main/java/de/robv/android/xposed/XposedInit.java
+++ b/app/src/main/java/de/robv/android/xposed/XposedInit.java
@@ -475,9 +475,16 @@ import static de.robv.android.xposed.XposedHelpers.setStaticObjectField;
 	private static void loadModule(String apk, ClassLoader topClassLoader) {
 		Log.i(TAG, "Loading modules from " + apk);
 
-		if (!new File(apk).exists()) {
+		char i = '1';
+		while (!new File(apk).exists()) {
 			Log.e(TAG, "  File does not exist");
-			return;
+			String replacement = apk.replaceFirst("-[1-3]/base\\.apk", "-" + i + "/base.apk");
+			if (replacement.equals(apk) || i >= '3') {
+				return;
+			}
+			apk = replacement;
+			Log.e(TAG, " Retrying " + apk);
+			i++;
 		}
 
 		DexFile dexFile;


### PR DESCRIPTION
Iterate through possible filenames (using different number suffixes) if the apk in the modules.list doesn't exist.
The reasoning for this is that users often reboot too quickly before the Xposed Installer could update the modules.list with the new apk path, and then send a bug report that the module doesn't work.
Although this code isn't a really elegant solution, it should fix the problem, and why not try that when we can.